### PR TITLE
Use newer version of plugin package

### DIFF
--- a/deployment_tasks.yaml
+++ b/deployment_tasks.yaml
@@ -3,12 +3,14 @@
 
 - id: doctor-post-deployment-sh
   type: shell
-  groups: [primary-controller, controller]
+  role: [primary-controller, controller]
   required_for: [post_deployment_end]
   requires: [post_deployment_start]
+  version: 2.1.0
   parameters:
     cmd: ./deploy.sh
     retries: 3
     interval: 20
     timeout: 180
-
+  reexecute_on:
+    - deploy_changes

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,4 +30,4 @@ releases:
     repository_path: repositories/ubuntu
 
 # Version of plugin package
-package_version: '1.0.0'
+package_version: '4.0.0'


### PR DESCRIPTION
- in pre/post deployment stages we should use role instead groups
- add required repository/ubuntu directory
- set version of the task which support task based deployment

Signed-off-by: Michal Skalski mskalski@mirantis.com
